### PR TITLE
Only test pushes to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
     paths-ignore:
       - 'README.md'
   push:
+    branches: 
+      - main
     paths-ignore:
       - 'README.md'
 


### PR DESCRIPTION
## Description

These workflows were testing twice on PRs as it is both a pr and a push. 

We have protected the main branch, so now we will only run on pushes to main.

PRs should only have one batch of tests now.