### PR TITLE
chore: Increase Channel List Page Size

### DIFF
--- a/internal/provider/channel_data_source.go
+++ b/internal/provider/channel_data_source.go
@@ -18,6 +18,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
+const channelListPageLimit = 1000
+
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
 	_ datasource.DataSource              = &ChannelDataSource{}
@@ -142,6 +144,7 @@ func getChannelByName(ctx context.Context, client *slack.Client, name string, ex
 		params := &slack.GetConversationsParameters{
 			ExcludeArchived: excludeArchived,
 			Cursor:          cursor,
+			Limit:           channelListPageLimit,
 		}
 
 		tflog.Trace(ctx, "Next Cursor: "+cursor)


### PR DESCRIPTION
## Description

The slack rate limit for channels is fairly aggressive. This makes channel listing very slow for workspaces with many channels. 

Setting `include_archived = false` doesn't actually improve speed as the filtering happens after pagination.

The only real solution is to max out the page size to reduce API calls when listing channels.