### PR TITLE
chore: update linting config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,15 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:
   disable-all: true
   enable:
     - durationcheck
+    - copyloopvar
     - errcheck
-    - exportloopref
     - forcetypeassert
     - godot
     - gofmt
@@ -20,7 +20,7 @@ linters:
     - nilerr
     - predeclared
     - staticcheck
-    - tenv
+    - usetesting
     - unconvert
     - unparam
     - unused


### PR DESCRIPTION
## Description

The golang ci linter is failing on deprecated linters. I've replaced them with their new counterparts.

#### Error
![image](https://github.com/user-attachments/assets/039bd2bf-88c6-445c-9d19-8aaaa64d23ef)
