### PR TITLE
chore: concurrency is unuseable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ on:
       - 'README.md'
 
 concurrency:
-  group: ${{ github.workflow }}-build-and-test
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{github.ref}}-build-and-test
+  cancel-in-progress: true
 
 # Testing only needs permissions to read the repository contents.
 permissions:


### PR DESCRIPTION
## Description

even with `cancel-in-progress: false` set, this isn't useable. This will not queue up pending jobs. they will be cancelled.

This is changed now to cancel pending of the same ref.